### PR TITLE
[Feature] 회원가입 API 추가 및 전역 예외 처리(에러 코드) 도입

### DIFF
--- a/backend/src/main/java/demo/cafemenu/domain/user/controller/UserController.java
+++ b/backend/src/main/java/demo/cafemenu/domain/user/controller/UserController.java
@@ -1,5 +1,28 @@
 package demo.cafemenu.domain.user.controller;
 
+import demo.cafemenu.domain.user.dto.SignupRequest;
+import demo.cafemenu.domain.user.dto.SignupResponse;
+import demo.cafemenu.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
 public class UserController {
+
+  private final UserService userService;
+
+  @PostMapping("/signup")
+  @ResponseStatus(HttpStatus.CREATED)
+  public SignupResponse signup(@Validated @RequestBody SignupRequest request) {
+    return userService.signup(request);
+  }
 
 }

--- a/backend/src/main/java/demo/cafemenu/domain/user/dto/SignupRequest.java
+++ b/backend/src/main/java/demo/cafemenu/domain/user/dto/SignupRequest.java
@@ -1,0 +1,23 @@
+package demo.cafemenu.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record SignupRequest (
+
+    @Email(message = "유효한 이메일 주소를 입력해 주세요.")
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    String email,
+
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$])[A-Za-z\\d!@#$]{8,}$",
+        message = "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자(!,@,#,$)를 각각 하나 이상 포함해야 합니다.")
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    String password,
+
+    @Size(min = 2, max = 20)
+    @NotBlank(message = "이름은 필수 입력 항목입니다.")
+    String name
+
+) {}

--- a/backend/src/main/java/demo/cafemenu/domain/user/dto/SignupResponse.java
+++ b/backend/src/main/java/demo/cafemenu/domain/user/dto/SignupResponse.java
@@ -1,0 +1,7 @@
+package demo.cafemenu.domain.user.dto;
+
+public record SignupResponse(
+    Long userId,
+    String email,
+    String name
+) {}

--- a/backend/src/main/java/demo/cafemenu/domain/user/reposiitory/UserRepository.java
+++ b/backend/src/main/java/demo/cafemenu/domain/user/reposiitory/UserRepository.java
@@ -1,4 +1,11 @@
 package demo.cafemenu.domain.user.reposiitory;
 
-public interface UserRepository {
+import demo.cafemenu.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+
 }

--- a/backend/src/main/java/demo/cafemenu/domain/user/reposiitory/UserRepository.java
+++ b/backend/src/main/java/demo/cafemenu/domain/user/reposiitory/UserRepository.java
@@ -7,5 +7,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
+  boolean existsByEmail(String email);
 
 }

--- a/backend/src/main/java/demo/cafemenu/domain/user/service/UserService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package demo.cafemenu.domain.user.service;
 
 import static demo.cafemenu.domain.user.entity.Role.ROLE_USER;
+import static demo.cafemenu.global.exception.ErrorCode.USER_ALREADY_EXISTS;
 
 import demo.cafemenu.domain.user.dto.SignupRequest;
 import demo.cafemenu.domain.user.dto.SignupResponse;
@@ -23,7 +24,7 @@ public class UserService {
 
     // 중복 가입 확인(이메일)
     if (userRepository.existsByEmail(request.email())) {
-      throw new BusinessException(ErrorCode.USER_EMAIL_DUPLICATE);
+      throw new BusinessException(USER_ALREADY_EXISTS);
     }
 
     User user = User.builder()

--- a/backend/src/main/java/demo/cafemenu/domain/user/service/UserService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/user/service/UserService.java
@@ -1,5 +1,38 @@
 package demo.cafemenu.domain.user.service;
 
+import static demo.cafemenu.domain.user.entity.Role.ROLE_USER;
+
+import demo.cafemenu.domain.user.dto.SignupRequest;
+import demo.cafemenu.domain.user.dto.SignupResponse;
+import demo.cafemenu.domain.user.entity.User;
+import demo.cafemenu.domain.user.reposiitory.UserRepository;
+import demo.cafemenu.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class UserService {
 
+  private final UserRepository userRepository;
+
+
+  public SignupResponse signup(SignupRequest request) {
+
+    // 중복 가입 확인(이메일)
+    if (userRepository.existsByEmail(email)) {
+      throw new BusinessException(ErrorCode.USER_EMAIL_DUPLICATE);
+    }
+
+    User user = User.builder()
+        .email(request.email())
+        .password(request.password()) // 추후 BCrypt.hashpw 를 사용하여 비밀번호 암호화 예정
+        .name(request.name())
+        .role(ROLE_USER)
+        .build();
+    userRepository.save(user);
+    return new SignupResponse(user.getId(), user.getEmail(), user.getName());
+  }
 }

--- a/backend/src/main/java/demo/cafemenu/domain/user/service/UserService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/user/service/UserService.java
@@ -22,7 +22,7 @@ public class UserService {
   public SignupResponse signup(SignupRequest request) {
 
     // 중복 가입 확인(이메일)
-    if (userRepository.existsByEmail(email)) {
+    if (userRepository.existsByEmail(request.email())) {
       throw new BusinessException(ErrorCode.USER_EMAIL_DUPLICATE);
     }
 

--- a/backend/src/main/java/demo/cafemenu/global/exception/BusinessException.java
+++ b/backend/src/main/java/demo/cafemenu/global/exception/BusinessException.java
@@ -1,0 +1,24 @@
+package demo.cafemenu.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@NoArgsConstructor
+@Builder
+public class BusinessException extends RuntimeException {
+
+  private ErrorCode errorCode;
+
+  public BusinessException(ErrorCode errorCode) {
+    super(errorCode.getDescription()); // 부모 생성자에 메시지 전달(RuntimeException)
+    this.errorCode = errorCode;
+  }
+
+  public HttpStatus getHttpStatus() {
+    return errorCode.getStatus();
+  }
+
+}

--- a/backend/src/main/java/demo/cafemenu/global/exception/ErrorCode.java
+++ b/backend/src/main/java/demo/cafemenu/global/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
   // 400 BAD REQUEST (잘못된 요청)
   INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다"),
   DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다"),
+  USER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 등록된 회원입니다."),
 
   // 401 UNAUTHORIZED (인증 실패)
 

--- a/backend/src/main/java/demo/cafemenu/global/exception/ErrorCode.java
+++ b/backend/src/main/java/demo/cafemenu/global/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
   // 400 BAD REQUEST (잘못된 요청)
+  DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다");
 
   // 401 UNAUTHORIZED (인증 실패)
 

--- a/backend/src/main/java/demo/cafemenu/global/exception/ErrorCode.java
+++ b/backend/src/main/java/demo/cafemenu/global/exception/ErrorCode.java
@@ -10,7 +10,7 @@ public enum ErrorCode {
 
   // 400 BAD REQUEST (잘못된 요청)
   INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다"),
-  DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다");
+  DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다"),
 
   // 401 UNAUTHORIZED (인증 실패)
 
@@ -19,6 +19,7 @@ public enum ErrorCode {
   // 404 NOT FOUND
 
   // 500 INTERNAL SERVER ERROR (서버 내부 오류)
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다.");
 
   private final HttpStatus status;
   private final String description;

--- a/backend/src/main/java/demo/cafemenu/global/exception/ErrorCode.java
+++ b/backend/src/main/java/demo/cafemenu/global/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
   // 400 BAD REQUEST (잘못된 요청)
+  INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다"),
   DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다");
 
   // 401 UNAUTHORIZED (인증 실패)

--- a/backend/src/main/java/demo/cafemenu/global/exception/ErrorCode.java
+++ b/backend/src/main/java/demo/cafemenu/global/exception/ErrorCode.java
@@ -1,0 +1,23 @@
+package demo.cafemenu.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+  // 400 BAD REQUEST (잘못된 요청)
+
+  // 401 UNAUTHORIZED (인증 실패)
+
+  // 403 FORBIDDEN (접근 금지)
+
+  // 404 NOT FOUND
+
+  // 500 INTERNAL SERVER ERROR (서버 내부 오류)
+
+  private final HttpStatus status;
+  private final String description;
+}

--- a/backend/src/main/java/demo/cafemenu/global/exception/ErrorResponse.java
+++ b/backend/src/main/java/demo/cafemenu/global/exception/ErrorResponse.java
@@ -1,0 +1,19 @@
+package demo.cafemenu.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ErrorResponse {
+
+  private ErrorCode errorCode;
+  private String errorMessage;
+
+}

--- a/backend/src/main/java/demo/cafemenu/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/demo/cafemenu/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package demo.cafemenu.global.exception;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  // 커스텀 예외처리
+  @ExceptionHandler(BusinessException.class)
+  public ResponseEntity<ErrorResponse> handleMeongnyangerangException(BusinessException e) {
+    log.error("{} is occurred.", e.getErrorCode());
+
+    return ResponseEntity
+        .status(e.getHttpStatus())
+        .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+  }
+
+}

--- a/backend/src/main/java/demo/cafemenu/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/demo/cafemenu/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package demo.cafemenu.global.exception;
 
 
+import static demo.cafemenu.global.exception.ErrorCode.INVALID_REQUEST;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/backend/src/main/java/demo/cafemenu/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/demo/cafemenu/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package demo.cafemenu.global.exception;
 
 
+import static demo.cafemenu.global.exception.ErrorCode.INTERNAL_SERVER_ERROR;
 import static demo.cafemenu.global.exception.ErrorCode.INVALID_REQUEST;
 
 import lombok.extern.slf4j.Slf4j;
@@ -42,6 +43,6 @@ public class GlobalExceptionHandler {
     log.error("Unexpected error: {}", e.getMessage(), e);
     return ResponseEntity
         .status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .body(new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR, "Internal server error"));
+        .body(new ErrorResponse(INTERNAL_SERVER_ERROR, "Internal server error"));
   }
 }

--- a/backend/src/main/java/demo/cafemenu/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/demo/cafemenu/global/exception/GlobalExceptionHandler.java
@@ -37,4 +37,11 @@ public class GlobalExceptionHandler {
     return new ErrorResponse(INVALID_REQUEST, errorMessage);
   }
 
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleAllExceptions(Exception e) {
+    log.error("Unexpected error: {}", e.getMessage(), e);
+    return ResponseEntity
+        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .body(new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR, "Internal server error"));
+  }
 }

--- a/backend/src/main/java/demo/cafemenu/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/demo/cafemenu/global/exception/GlobalExceptionHandler.java
@@ -2,8 +2,11 @@ package demo.cafemenu.global.exception;
 
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
@@ -18,6 +21,18 @@ public class GlobalExceptionHandler {
     return ResponseEntity
         .status(e.getHttpStatus())
         .body(new ErrorResponse(e.getErrorCode(), e.getMessage()));
+  }
+
+  // 유효성 검사 예외처리
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    log.error("Validation failed: {}", e.getMessage());
+
+    // 첫 번째 유효성 검증 에러 메시지를 가져옴 (모든 에러 메시지로 반환할지 결정도 가능)
+    String errorMessage = e.getBindingResult().getFieldError().getDefaultMessage();
+
+    return new ErrorResponse(INVALID_REQUEST, errorMessage);
   }
 
 }


### PR DESCRIPTION
## 📌 과제 설명

*  **회원가입 API**를 추가했습니다.
* 동시에 공통으로 재사용할 **전역 예외 처리 체계**(에러 코드/응답 포맷)를 1차 도입했습니다.

---

## 👩‍💻 요구 사항과 구현 내용

### 1) 전역 에러 처리(1차)

* `ErrorCode` enum 신설:

  * `INVALID_REQUEST(400)`, `DUPLICATE_EMAIL(400)`, `USER_ALREADY_EXISTS(400)`, `INTERNAL_SERVER_ERROR(500)`
* `BusinessException`(런타임 예외, `ErrorCode` 보유) 추가
* `ErrorResponse`(응답 바디: `errorCode`, `errorMessage`) 추가
* `GlobalExceptionHandler` 추가

  * `BusinessException` → 상태코드 + `ErrorResponse` 반환
  * `MethodArgumentNotValidException` → 400 + 첫 번째 필드 오류 메시지 반환
  * `Exception` → 500 + 기본 메시지 반환

### 2) 회원가입 API

* DTO

  * `SignupRequest`: `email`, `password`, `name`

    * 이메일 형식/NotBlank 검증
    * 비밀번호 정규식 검증(영문/숫자/특수문자 포함, 8자 이상)
    * 이름 길이(2~20) 검증
  * `SignupResponse`: `userId`, `email`, `name`
* Controller

  * `UserController` → `POST /api/user/signup` (201 Created)
* Service

  * `UserService.signup()`

    * `UserRepository.existsByEmail()`로 **중복 이메일 검사** → `USER_ALREADY_EXISTS` 예외
    * 사용자 생성 후 저장 → `SignupResponse` 반환
  * ⚠️ 현재는 비밀번호 **평문 저장(주석: 추후 BCrypt 적용 예정)**
* Repository

  * `UserRepository` (JpaRepository) + `existsByEmail()`

---

## ✅ 피드백 반영사항

* (최초 도입 PR이므로 해당 없음)

---

## ✅ PR 포인트 & 궁금한 점

1. **엔드포인트 위치**

   * 현재 `UserController`에 `/api/user/signup`으로 두었습니다.

2. **비밀번호 저장**

   * 현재 평문 저장 → 다음 PR에서 `PasswordEncoder(BCrypt)`를 적용하겠습니다.

---
