### PR TITLE
[Feature] 로그인 API 구현 및 JWT 연동 (User/Admin 공용)

### DIFF
--- a/backend/src/main/java/demo/cafemenu/domain/user/controller/UserController.java
+++ b/backend/src/main/java/demo/cafemenu/domain/user/controller/UserController.java
@@ -19,6 +19,7 @@ public class UserController {
 
   private final UserService userService;
 
+  // 사용자 회원가입 API
   @PostMapping("/signup")
   @ResponseStatus(HttpStatus.CREATED)
   public SignupResponse signup(@Validated @RequestBody SignupRequest request) {

--- a/backend/src/main/java/demo/cafemenu/domain/user/controller/UserController.java
+++ b/backend/src/main/java/demo/cafemenu/domain/user/controller/UserController.java
@@ -1,8 +1,11 @@
 package demo.cafemenu.domain.user.controller;
 
+import demo.cafemenu.domain.user.dto.LoginRequest;
+import demo.cafemenu.domain.user.dto.LoginResponse;
 import demo.cafemenu.domain.user.dto.SignupRequest;
 import demo.cafemenu.domain.user.dto.SignupResponse;
 import demo.cafemenu.domain.user.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
@@ -24,6 +27,13 @@ public class UserController {
   @ResponseStatus(HttpStatus.CREATED)
   public SignupResponse signup(@Validated @RequestBody SignupRequest request) {
     return userService.signup(request);
+  }
+
+  // 로그인 API (User/Admin 공용)
+  @PostMapping("/login")
+  @ResponseStatus(HttpStatus.OK)
+  public LoginResponse login(@Valid @RequestBody LoginRequest request) {
+    return userService.login(request);
   }
 
 }

--- a/backend/src/main/java/demo/cafemenu/domain/user/dto/LoginRequest.java
+++ b/backend/src/main/java/demo/cafemenu/domain/user/dto/LoginRequest.java
@@ -1,0 +1,18 @@
+package demo.cafemenu.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record LoginRequest (
+
+    @Email(message = "유효한 이메일 주소를 입력해 주세요.")
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    String email,
+
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$])[A-Za-z\\d!@#$]{8,}$",
+    message = "비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자(!,@,#,$)를 각각 하나 이상 포함해야 합니다.")
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    String password
+
+){}

--- a/backend/src/main/java/demo/cafemenu/domain/user/dto/LoginResponse.java
+++ b/backend/src/main/java/demo/cafemenu/domain/user/dto/LoginResponse.java
@@ -1,0 +1,14 @@
+package demo.cafemenu.domain.user.dto;
+
+public record LoginResponse(
+    String accessToken,
+    String tokenType,
+    String role,
+    Long userId,
+    String email,
+    String name
+) {
+  public static LoginResponse of(String token, String role, Long userId, String email, String name) {
+    return new LoginResponse(token, "Bearer", role, userId, email, name);
+  }
+}

--- a/backend/src/main/java/demo/cafemenu/domain/user/service/UserService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/user/service/UserService.java
@@ -1,7 +1,9 @@
 package demo.cafemenu.domain.user.service;
 
 import static demo.cafemenu.domain.user.entity.Role.ROLE_USER;
+import static demo.cafemenu.global.exception.ErrorCode.INVALID_CREDENTIALS;
 import static demo.cafemenu.global.exception.ErrorCode.USER_ALREADY_EXISTS;
+import static demo.cafemenu.global.exception.ErrorCode.USER_NOT_FOUND;
 
 import demo.cafemenu.domain.user.dto.LoginRequest;
 import demo.cafemenu.domain.user.dto.LoginResponse;
@@ -62,7 +64,7 @@ public class UserService {
 
       // 3) 추가 정보(name 등) 응답에 포함하려면 DB 조회
       User user = userRepository.findByEmail(principal.getEmail())
-          .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+          .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
 
       // 4) 토큰 발급
       String token = jwtTokenProvider.createAccessToken(user);
@@ -72,7 +74,7 @@ public class UserService {
           principal.getId(), principal.getEmail(), user.getName());
 
     } catch (BadCredentialsException | UsernameNotFoundException e) {
-      throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
+      throw new BusinessException(INVALID_CREDENTIALS);
     }
   }
 }

--- a/backend/src/main/java/demo/cafemenu/domain/user/service/UserService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/user/service/UserService.java
@@ -3,12 +3,21 @@ package demo.cafemenu.domain.user.service;
 import static demo.cafemenu.domain.user.entity.Role.ROLE_USER;
 import static demo.cafemenu.global.exception.ErrorCode.USER_ALREADY_EXISTS;
 
+import demo.cafemenu.domain.user.dto.LoginRequest;
+import demo.cafemenu.domain.user.dto.LoginResponse;
 import demo.cafemenu.domain.user.dto.SignupRequest;
 import demo.cafemenu.domain.user.dto.SignupResponse;
 import demo.cafemenu.domain.user.entity.User;
 import demo.cafemenu.domain.user.reposiitory.UserRepository;
 import demo.cafemenu.global.exception.BusinessException;
+import demo.cafemenu.global.jwt.JwtTokenProvider;
+import demo.cafemenu.global.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +29,8 @@ public class UserService {
 
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
+  private final AuthenticationManager authenticationManager;
+  private final JwtTokenProvider jwtTokenProvider;
 
   public SignupResponse signup(SignupRequest request) {
 
@@ -37,5 +48,31 @@ public class UserService {
 
     userRepository.save(user);
     return new SignupResponse(user.getId(), user.getEmail(), user.getName());
+  }
+
+  public LoginResponse login(LoginRequest request) {
+    try {
+      // 1) 이메일/비번 인증
+      Authentication authentication = authenticationManager.authenticate(
+          new UsernamePasswordAuthenticationToken(request.email(), request.password())
+      );
+
+      // 2) 인증 성공 시 principal 꺼내기
+      UserDetailsImpl principal = (UserDetailsImpl) authentication.getPrincipal();
+
+      // 3) 추가 정보(name 등) 응답에 포함하려면 DB 조회
+      User user = userRepository.findByEmail(principal.getEmail())
+          .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+      // 4) 토큰 발급
+      String token = jwtTokenProvider.createAccessToken(user);
+
+      // 5) 응답
+      return LoginResponse.of(token, principal.getRole().name(),
+          principal.getId(), principal.getEmail(), user.getName());
+
+    } catch (BadCredentialsException | UsernameNotFoundException e) {
+      throw new BusinessException(ErrorCode.INVALID_CREDENTIALS);
+    }
   }
 }

--- a/backend/src/main/java/demo/cafemenu/global/config/SecurityConfig.java
+++ b/backend/src/main/java/demo/cafemenu/global/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
             // 공개 엔드포인트 (회원가입/로그인은 다음 브랜치에서 구현 예정)
             .requestMatchers("/h2-console/**").permitAll()
             .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-            .requestMatchers(HttpMethod.POST, "/api/auth/signup", "/api/auth/login").permitAll()
+            .requestMatchers(HttpMethod.POST, "/api/user/signup", "/api/user/login").permitAll()
 
             // 역할 기반
             .requestMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN")

--- a/backend/src/main/java/demo/cafemenu/global/exception/ErrorCode.java
+++ b/backend/src/main/java/demo/cafemenu/global/exception/ErrorCode.java
@@ -14,10 +14,12 @@ public enum ErrorCode {
   USER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 등록된 회원입니다."),
 
   // 401 UNAUTHORIZED (인증 실패)
+  INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다."),
 
   // 403 FORBIDDEN (접근 금지)
 
   // 404 NOT FOUND
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
 
   // 500 INTERNAL SERVER ERROR (서버 내부 오류)
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다.");


### PR DESCRIPTION
**PR 제목**
feat(auth): 로그인 API 구현 및 JWT 연동 (User/Admin 공용)

---

## 📌 과제 설명

* `User`/`Admin`이 공용으로 사용할 수 있는 **로그인 API**를 추가했습니다.
* 스프링 시큐리티의 `AuthenticationManager`로 인증을 처리하고, 성공 시 **JWT 액세스 토큰**을 발급합니다.

---

## 👩‍💻 요구 사항과 구현 내용

1. **DTO 추가**

   * `LoginRequest` : `email`, `password`에 Bean Validation 적용(이메일 형식, 비밀번호 정규식).
   * `LoginResponse` : `accessToken`, `tokenType(Bearer)`, `role`, `userId`, `email`, `name` 반환.

2. **Controller**

   * `UserController`

     * `POST /api/user/login` : 로그인 엔드포인트 추가, 요청 검증 후 `UserService.login()` 호출.

3. **Service**

   * `UserService.login(LoginRequest)`

     * `AuthenticationManager.authenticate()`로 이메일/비밀번호 인증.
     * 인증 성공 시 `UserDetailsImpl`을 꺼내고, DB에서 `User` 조회해 `name` 포함.
     * `JwtTokenProvider.createAccessToken(user)`로 토큰 발급.
     * `LoginResponse` 조립 후 반환.

4. **Security 설정 연동**

   * `SecurityConfig`에서 **`POST /api/user/login`** 및 **`POST /api/user/signup`** 공개(`permitAll`) 경로로 사용.

5. **예외/에러 응답**

   * 로그인 실패 시 `BusinessException(INVALID_CREDENTIALS)` 또는 `USER_NOT_FOUND` 사용.

---

## ✅ 피드백 반영사항

* (해당 사항 없음)

---

## ✅ PR 포인트 & 궁금한 점

* **검증 강도**: 비밀번호 정규식이 엄격합니다(`!@#$` 중 하나 필수). 프론트(Next.js)와 UX 합의가 필요할 수 있습니다.
* **토큰 정책**: 액세스 토큰 유효기간은 현재 30분입니다.
* **관리자 로그인**: Admin은 DB에 미리 계정이 존재하면 동일 엔드포인트로 로그인 가능하며, 응답의 `role`이 `ROLE_ADMIN`으로 내려옵니다.
