### PR TITLE
feat: 회원가입 & 로그인 API 연동 + AuthContext 개선

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "jwt-decode": "^4.0.0",
         "next": "15.5.4",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -4132,6 +4133,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,19 +9,20 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "jwt-decode": "^4.0.0",
+    "next": "15.5.4",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.5.4"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.5.4",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/frontend/src/app/context/AuthContext.tsx
+++ b/frontend/src/app/context/AuthContext.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  ReactNode,
+  useCallback,
+} from "react";
+import { useRouter } from "next/navigation";
+import { authApi, UserInfo as OriginalUserInfo, tokenUtils } from "../services/api";
+
+interface UserInfo extends OriginalUserInfo {
+  password?: string;
+}
+
+interface AuthContextType {
+  user: UserInfo | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: (email: string, password: string) => Promise<UserInfo | null>;
+  logout: () => void;
+  hasRole: (role: string) => boolean;
+  isAdmin: boolean;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<UserInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const router = useRouter();
+
+  const mockAdmin: UserInfo = {
+    id: 999,
+    email: "admin@test.com",
+    roles: ["ROLE_ADMIN"],
+    name: "Admin",
+    password: "Admin1234!",
+  };
+
+  // 세션 복원
+  React.useEffect(() => {
+    try {
+      const token = localStorage.getItem("token");
+      const userEmail = localStorage.getItem("userEmail");
+      if (token === "mock-token" && userEmail === "admin@test.com") {
+        setUser(mockAdmin);
+        setIsLoading(false);
+        return;
+      }
+      if (token && tokenUtils.isValid(token)) {
+        const decoded = tokenUtils.getUserInfo(token);
+        if (decoded) {
+          const normalizedUser: UserInfo = {
+            ...decoded,
+            roles: Array.isArray(decoded.roles) ? decoded.roles : [decoded.roles],
+          };
+          setUser(normalizedUser as UserInfo);
+        }
+      }
+    } catch (e) {
+      console.error("restore session failed:", e);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // 로그인
+  const login = async (
+    email: string,
+    password: string
+  ): Promise<UserInfo | null> => {
+    // 목업 관리자 계정 처리
+    if (email === "admin@test.com" && password === mockAdmin.password) {
+      setUser(mockAdmin);
+      localStorage.setItem("token", "mock-token");
+      localStorage.setItem("userEmail", mockAdmin.email);
+      setIsLoading(false);
+      return mockAdmin;
+    }
+
+    setIsLoading(true);
+    try {
+      const res = await authApi.login({ email, password });
+
+      if (res?.accessToken) {
+        localStorage.setItem("token", res.accessToken);
+        localStorage.setItem("userEmail", res.email);
+
+        const nextUser: UserInfo = {
+          id: res.userId,
+          email: res.email,
+          roles: Array.isArray(res.roles) ? res.roles : [res.roles], // 항상 배열로 보정됨
+          name: res.name,
+        };
+
+        setUser(nextUser);
+        return nextUser;
+      }
+      return null;
+    } catch (err) {
+      console.error("AuthContext Login failed:", err);
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 로그아웃
+  const logout = () => {
+    localStorage.removeItem("token");
+    localStorage.removeItem("userEmail");
+    const redirectPath = user?.roles?.includes("ROLE_ADMIN")
+      ? "/admin/login"
+      : "/login";
+    setUser(null);
+    router.push(redirectPath);
+  };
+
+  // 권한 체크
+  const hasRole = useCallback(
+    (role: string) => user?.roles?.includes(role) ?? false,
+    [user]
+  );
+
+  const isAdmin = useMemo(
+    () => user?.roles?.includes("ROLE_ADMIN") ?? false,
+    [user]
+  );
+
+  const value = useMemo<AuthContextType>(
+    () => ({
+      user,
+      isAuthenticated: !!user,
+      isLoading,
+      login,
+      logout,
+      hasRole,
+      isAdmin,
+    }),
+    [user, isLoading, hasRole, isAdmin]
+  );
+
+  return (
+    <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within an AuthProvider");
+  return ctx;
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,99 @@
+"use client";
+import React, { useState } from "react";
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useAuth } from '../context/AuthContext';
+import { ROLES } from '../utils/roles';
+import Image from "next/image";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loginError, setLoginError] = useState("");
+  const { login, isLoading } = useAuth();
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoginError(""); 
+
+    try {
+      const trimmedEmail = email.trim();
+      const trimmedPassword = password.trim();
+      const userInfo = await login(trimmedEmail, trimmedPassword);
+      
+      if (userInfo) {
+        const isAdmin = userInfo.roles?.includes(ROLES.ADMIN);
+        alert(`로그인 성공! (${isAdmin ? '관리자' : '사용자'} 권한)`);
+        router.push(isAdmin ? '/admin/dashboard' : '/user');
+      } else {
+        setLoginError("이메일 또는 비밀번호가 일치하지 않습니다.");
+      }
+    } catch (error) {
+      console.error('Login error:', error);
+      setLoginError("로그인 중 오류가 발생했습니다. 다시 시도해주세요.");
+    }
+  };
+
+  return (
+    <div className="container-fluid" style={{ height: 'calc(100vh - 56px)' }}>
+      <div className="row g-0 h-100">
+        {/* Image Column */}
+        <div className="col-md-6 col-lg-7 d-none d-md-block">
+          <Image
+            src="/images/coffee-wholebean.png"
+            alt="Login background"
+            width={800}
+            height={1200}
+            style={{ objectFit: 'cover', height: '100%', width: '100%' }}
+          />
+        </div>
+
+        {/* Form Column */}
+        <div className="col-md-6 col-lg-5 d-flex align-items-center justify-content-center bg-light">
+          <div className="w-100" style={{ maxWidth: '400px' }}>
+            <div className="card-body p-4 p-sm-5">
+              <h1 className="text-center mb-4 fw-bold">로그인</h1>
+              <form onSubmit={handleSubmit}>
+                {loginError && <div className="alert alert-danger text-center mb-3">{loginError}</div>}
+                
+                <div className="form-floating mb-3">
+                  <input
+                    id="email"
+                    type="email"
+                    className="form-control"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="name@example.com"
+                    required
+                  />
+                  <label htmlFor="email">이메일</label>
+                </div>
+
+                <div className="form-floating mb-4">
+                  <input
+                    id="password"
+                    type="password"
+                    className="form-control"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="Password"
+                    required
+                  />
+                  <label htmlFor="password">비밀번호</label>
+                </div>
+
+                <button type="submit" className="btn btn-dark w-100 py-2" disabled={isLoading}>
+                  {isLoading ? '로그인 중...' : '로그인'}
+                </button>
+              </form>
+              <div className="text-center mt-4">
+                <p className="mb-0">계정이 없으신가요? <Link href="/user/signup" className="fw-bold">회원가입</Link></p>
+              </div>   
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/services/api.ts
+++ b/frontend/src/app/services/api.ts
@@ -1,0 +1,408 @@
+import { jwtDecode } from "jwt-decode";
+
+// API 기본 설정
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8080";
+
+// 타입 정의
+export interface Product {
+  id: number;
+  name: string;
+  price: number;
+  category: string;
+  description?: string;
+  stock?: number;
+}
+
+export interface CartItem {
+  productId: number;
+  quantity: number;
+  price: number;
+}
+
+export interface Order {
+  id: number;
+  userId: number;
+  items: CartItem[];
+  totalAmount: number;
+  status: string;
+  shippingAddress?: string;
+  createdAt: string;
+}
+
+export interface UserInfo {
+  id: number;
+  email: string;
+  roles: string[];
+  name: string;
+}
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  accessToken: string;
+  tokenType: string;
+  roles: string[];   // 항상 배열로 통일
+  userId: number;
+  email: string;
+  name: string;
+}
+
+export interface ApiResponse<T> {
+  data: T;
+  message?: string;
+  success: boolean;
+}
+
+interface DecodedToken {
+  id?: number;
+  userId?: number;
+  sub?: string;
+  email?: string;
+  role?: string;
+  roles?: string[];
+  name?: string;
+  exp?: number;
+}
+
+// JWT 토큰 관리 유틸리티
+export const tokenUtils = {
+  isValid: (token: string): boolean => {
+    if (!token) return false;
+    try {
+      const payload = jwtDecode<DecodedToken>(token);
+      const currentTime = Math.floor(Date.now() / 1000);
+      return payload.exp ? payload.exp > currentTime : false;
+    } catch (error) {
+      console.error('Token validation error:', error);
+      return false;
+    }
+  },
+
+  getTimeUntilExpiry: (token: string): number => {
+    if (!token) return 0;
+    try {
+      const payload = jwtDecode<DecodedToken>(token);
+      const currentTime = Math.floor(Date.now() / 1000);
+      return payload.exp ? Math.max(0, payload.exp - currentTime) : 0;
+    } catch (error) {
+      console.error('Token expiry check error:', error);
+      return 0;
+    }
+  },
+
+  getUserInfo: (token: string): UserInfo | null => {
+    if (!token) return null;
+    try {
+      const payload = jwtDecode<DecodedToken>(token);
+      return {
+        id: payload.id || payload.userId || 0,
+        email: payload.sub || payload.email || '',
+        roles: payload.roles ?? (payload.role ? [payload.role] : []),
+        name: payload.name || '사용자',
+      };
+    } catch (error) {
+      console.error('Token user info extraction error:', error);
+      return null;
+    }
+  },
+};
+
+// API 요청 헬퍼 함수
+async function apiRequest<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+  const url = `${API_BASE_URL}${endpoint}`;
+
+  const defaultHeaders: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : null;
+  if (token) {
+    if (token === "mock-token") {
+      defaultHeaders['Authorization'] = `Bearer ${token}`;
+    } else if (tokenUtils.isValid(token)) {
+      defaultHeaders['Authorization'] = `Bearer ${token}`;
+    }
+  }
+
+  const config: RequestInit = {
+    ...options,
+    headers: {
+      ...defaultHeaders,
+      ...options.headers,
+    },
+  };
+
+  try {
+    const response = await fetch(url, config);
+
+    if (!response.ok) {
+      let errorMessage = `HTTP error! status: ${response.status}`;
+      if (response.status === 401) {
+        localStorage.removeItem('token');
+        localStorage.removeItem('userEmail');
+        errorMessage = 'Session expired. Please log in again.';
+      }
+
+      try {
+        const errorData = await response.json();
+        errorMessage = errorData.message || errorData.error || errorMessage;
+      } catch (e) {
+        try {
+          const errorText = await response.text();
+          if (errorText) errorMessage = errorText;
+        } catch (textError) {
+          // 텍스트 파싱 실패 시 기본 메시지 사용
+        }
+      }
+
+      throw new Error(errorMessage);
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error('API request failed:', {
+      url,
+      method: options.method || 'GET',
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}
+
+// 래핑된 API 응답용 헬퍼 함수
+async function wrappedApiRequest<T>(endpoint: string, options: RequestInit = {}): Promise<ApiResponse<T>> {
+  try {
+    const data = await apiRequest<T>(endpoint, options);
+    return {
+      data,
+      success: true,
+      message: 'Request successful',
+    };
+  } catch (error) {
+    return {
+      data: null as T,
+      success: false,
+      message: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+// 인증 관련 API
+export const authApi = {
+  login: async (credentials: LoginRequest): Promise<LoginResponse> => {
+    try {
+      const response = await apiRequest<LoginResponse>('/api/user/login', {
+        method: 'POST',
+        body: JSON.stringify(credentials),
+      });
+
+      // role을 roles로 보정하여 항상 배열 형태로 사용
+      const normalizedRoles = response.roles ?? [];
+      response.roles = normalizedRoles;
+      return response;
+    } catch (error) {
+      console.error('Login API failed:', error);
+      throw error;
+    }
+  },
+
+  getCurrentUser: async (): Promise<ApiResponse<UserInfo>> => {
+    try {
+      return await wrappedApiRequest<UserInfo>('/api/user/me');
+    } catch (error) {
+      console.error('Get current user API failed:', error);
+      throw error;
+    }
+  },
+
+  logout: async (): Promise<ApiResponse<null>> => {
+    try {
+      return await wrappedApiRequest<null>('/api/user/logout', {
+        method: 'POST',
+      });
+    } catch (error) {
+      console.error('Logout API failed:', error);
+      throw error;
+    }
+  },
+
+  register: async (userData: {
+    email: string;
+    password: string;
+    name: string;
+  }): Promise<ApiResponse<UserInfo>> => {
+    try {
+      return await wrappedApiRequest<UserInfo>('/api/user/signup', {
+        method: 'POST',
+        body: JSON.stringify(userData),
+      });
+    } catch (error) {
+      console.error('Register API failed:', error);
+      throw error;
+    }
+  },
+};
+
+// 주문 관련 API
+export const orderApi = {
+  getAllOrders: async (): Promise<ApiResponse<Order[]>> => {
+    try {
+      return await wrappedApiRequest<Order[]>('/api/orders');
+    } catch (error) {
+      console.error('Get all orders API failed:', error);
+      throw error;
+    }
+  },
+
+  getUserOrders: async (userId?: number): Promise<ApiResponse<Order[]>> => {
+    try {
+      const endpoint = userId ? `/api/orders/user/${userId}` : '/api/orders/user';
+      return await wrappedApiRequest<Order[]>(endpoint);
+    } catch (error) {
+      console.error('Get user orders API failed:', error);
+      throw error;
+    }
+  },
+
+  getOrderById: async (orderId: number): Promise<ApiResponse<Order>> => {
+    try {
+      return await wrappedApiRequest<Order>(`/api/orders/${orderId}`);
+    } catch (error) {
+      console.error('Get order by ID API failed:', error);
+      throw error;
+    }
+  },
+
+  createOrder: async (orderData: {
+    items: CartItem[];
+    totalAmount: number;
+    shippingAddress?: string;
+  }): Promise<ApiResponse<Order>> => {
+    try {
+      return await wrappedApiRequest<Order>('/api/orders', {
+        method: 'POST',
+        body: JSON.stringify(orderData),
+      });
+    } catch (error) {
+      console.error('Create order API failed:', error);
+      throw error;
+    }
+  },
+
+  updateOrderStatus: async (
+    orderId: number,
+    status: string
+  ): Promise<ApiResponse<Order>> => {
+    try {
+      return await wrappedApiRequest<Order>(`/api/orders/${orderId}/status`, {
+        method: 'PUT',
+        body: JSON.stringify({ status }),
+      });
+    } catch (error) {
+      console.error('Update order status API failed:', error);
+      throw error;
+    }
+  },
+
+  cancelOrder: async (orderId: number): Promise<ApiResponse<Order>> => {
+    try {
+      return await wrappedApiRequest<Order>(`/api/orders/${orderId}/cancel`, {
+        method: 'PUT',
+      });
+    } catch (error) {
+      console.error('Cancel order API failed:', error);
+      throw error;
+    }
+  },
+};
+
+// 상품 관련 API
+export const productApi = {
+  getAllProducts: async (params?: {
+    category?: string;
+    search?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<ApiResponse<Product[]>> => {
+    try {
+      let endpoint = '/api/products';
+      if (params) {
+        const searchParams = new URLSearchParams();
+        Object.entries(params).forEach(([key, value]) => {
+          if (value !== undefined) {
+            searchParams.append(key, value.toString());
+          }
+        });
+        if (searchParams.toString()) {
+          endpoint += `?${searchParams.toString()}`;
+        }
+      }
+      return await wrappedApiRequest<Product[]>(endpoint);
+    } catch (error) {
+      console.error('Get all products API failed:', error);
+      throw error;
+    }
+  },
+
+  getProductById: async (productId: number): Promise<ApiResponse<Product>> => {
+    try {
+      return await wrappedApiRequest<Product>(`/api/products/${productId}`);
+    } catch (error) {
+      console.error('Get product by ID API failed:', error);
+      throw error;
+    }
+  },
+
+  createProduct: async (productData: Omit<Product, 'id'>): Promise<ApiResponse<Product>> => {
+    try {
+      return await wrappedApiRequest<Product>('/api/products', {
+        method: 'POST',
+        body: JSON.stringify(productData),
+      });
+    } catch (error) {
+      console.error('Create product API failed:', error);
+      throw error;
+    }
+  },
+
+  updateProduct: async (
+    productId: number,
+    productData: Partial<Product>
+  ): Promise<ApiResponse<Product>> => {
+    try {
+      return await wrappedApiRequest<Product>(`/api/products/${productId}`, {
+        method: 'PUT',
+        body: JSON.stringify(productData),
+      });
+    } catch (error) {
+      console.error('Update product API failed:', error);
+      throw error;
+    }
+  },
+
+  deleteProduct: async (productId: number): Promise<ApiResponse<null>> => {
+    try {
+      return await wrappedApiRequest<null>(`/api/products/${productId}`, {
+        method: 'DELETE',
+      });
+    } catch (error) {
+      console.error('Delete product API failed:', error);
+      throw error;
+    }
+  },
+};
+
+// 카테고리 관련 API
+export const categoryApi = {
+  getAllCategories: async (): Promise<ApiResponse<string[]>> => {
+    try {
+      return await wrappedApiRequest<string[]>('/api/categories');
+    } catch (error) {
+      console.error('Get all categories API failed:', error);
+      throw error;
+    }
+  },
+};

--- a/frontend/src/app/user/layout.tsx
+++ b/frontend/src/app/user/layout.tsx
@@ -1,0 +1,3 @@
+export default function UserLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/user/page.tsx
+++ b/frontend/src/app/user/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import ProductList from "@/app/components/ProductList";
+import CartSummary from "@/app/components/CartSummary";
+import { useCart } from '../context/CartContext';
+
+export default function UserPage() {
+  const { products, cartItems, totalAmount, addToCart, deleteToCart, checkout, isLoading } = useCart();
+
+  if (isLoading) {
+    return <div className="text-center"><h2>상품 목록을 불러오는 중...</h2></div>;
+  }
+
+  return (
+    <div className="row">
+      <div className="col-md-8">
+        <ProductList products={products} onAddToCart={addToCart} deleteToCart={deleteToCart} />
+      </div>
+      <div className="col-md-4">
+        <CartSummary cartItems={cartItems} totalAmount={totalAmount} onCheckout={checkout} />
+      </div>
+    </div>
+  );
+}
+
+

--- a/frontend/src/app/user/signup/page.tsx
+++ b/frontend/src/app/user/signup/page.tsx
@@ -1,0 +1,155 @@
+"use client";
+import React, { useState } from "react";
+import Link from 'next/link';
+import Image from "next/image";
+
+export default function SignupPage() {
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [password, setPassword] = useState("");
+
+  const [emailError, setEmailError] = useState("");
+  const [nameError, setNameError] = useState("");
+  const [passwordError, setPasswordError] = useState("");
+
+  const validateForm = () => {
+    let isValid = true;
+    setEmailError("");
+    setNameError("");
+    setPasswordError("");
+
+    // Email Validation
+    if (!email) {
+      setEmailError("이메일은 필수 입력 항목입니다.");
+      isValid = false;
+    } else if (!/^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/.test(email)) {
+      setEmailError("유효한 이메일 주소를 입력해 주세요.");
+      isValid = false;
+    }
+
+    // Name Validation
+    if (!name) {
+      setNameError("이름은 필수 입력 항목입니다.");
+      isValid = false;
+    } else if (name.length < 2 || name.length > 20) {
+      setNameError("이름은 2자 이상 20자 이하로 입력해야 합니다.");
+      isValid = false;
+    }
+
+    // Password Validation
+    const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$])[A-Za-z\d!@#$]{8,}$/;
+    if (!password) {
+      setPasswordError("비밀번호는 필수 입력 항목입니다.");
+      isValid = false;
+    } else if (!passwordRegex.test(password)) {
+      setPasswordError("비밀번호는 최소 8자 이상이며, 영문, 숫자, 특수문자(!, @,#,$)를 각각 하나 이상 포함해야 합니다.");
+      isValid = false;
+    }
+
+    return isValid;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+    
+    // Backend API call
+    const res = await fetch("http://localhost:8080/api/user/signup", {
+      method: "POST",
+      headers: {
+        "Content-Type" : "application/json",
+      },
+      body: JSON.stringify({ email: email.trim(), name: name.trim(), password: password.trim() }),
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      console.log("회원가입 성공:", data);
+      alert("회원가입 성공!");
+      // Optionally redirect to login page or home page
+    } else {
+      const err = await res.json();
+      console.error("회원가입 실패:", err);
+      alert(`회원가입 실패: ${err.message || "서버 오류"}`);
+    }
+  };
+
+  return (
+    <div className="container-fluid" style={{ height: 'calc(100vh - 56px)' }}>
+      <div className="row g-0 h-100">
+        {/* Image Column */}
+        <div className="col-md-6 col-lg-7 d-none d-md-block">
+          <Image
+            src="/images/coffee-darkroast.png"
+            alt="Signup background"
+            width={800}
+            height={1200}
+            style={{ objectFit: 'cover', height: '100%', width: '100%' }}
+          />
+        </div>
+
+        {/* Form Column */}
+        <div className="col-md-6 col-lg-5 d-flex align-items-center justify-content-center bg-light">
+          <div className="w-100" style={{ maxWidth: '400px' }}>
+            <div className="card-body p-4 p-sm-5">
+              <h1 className="text-center mb-4 fw-bold">회원가입</h1>
+              <form onSubmit={handleSubmit} noValidate>
+                <div className="form-floating mb-3">
+                  <input
+                    id="name"
+                    type="text"
+                    className={`form-control ${nameError ? 'is-invalid' : ''}`}
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="이름"
+                    required
+                  />
+                  <label htmlFor="name">이름</label>
+                  {nameError && <div className="invalid-feedback">{nameError}</div>}
+                </div>
+
+                <div className="form-floating mb-3">
+                  <input
+                    id="email"
+                    type="email"
+                    className={`form-control ${emailError ? 'is-invalid' : ''}`}
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="name@example.com"
+                    required
+                  />
+                  <label htmlFor="email">이메일</label>
+                  {emailError && <div className="invalid-feedback">{emailError}</div>}
+                </div>
+
+                <div className="form-floating mb-4">
+                  <input
+                    id="password"
+                    type="password"
+                    className={`form-control ${passwordError ? 'is-invalid' : ''}`}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="비밀번호"
+                    required
+                  />
+                  <label htmlFor="password">비밀번호</label>
+                  {passwordError && <div className="invalid-feedback">{passwordError}</div>}
+                </div>
+
+                <button type="submit" className="btn btn-dark w-100 py-2">
+                  회원가입
+                </button>
+              </form>
+              <div className="text-center mt-4">
+                <p className="mb-0">이미 계정이 있으신가요? <Link href="/login" className="fw-bold">로그인</Link></p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 회원가입 및 로그인 API를 프론트엔드와 연동
- AuthContext 개선하여 사용자 인증/인가 흐름 구현
- 관리자 전용 목업 계정도 추가, 관리자 페이지 접근 테스트 완료

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
**1. 회원가입 & 로그인 API 연동**
- `/api/user/signup` → 회원가입 요청 시 DB에 사용자 저장 
- `/api/user/login` → 로그인 요청 시 JWT 액세스 토큰 발급 
- 로그인 성공 시:
  - 발급받은 accessToken과 사용자 이메일을 localStorage에 저장 
  - 이후 요청(apiRequest) 시 Authorization 헤더(Bearer <token>) 자동 포함 

**2. AuthContext 개선**
- **세션 복원**
  - 초기 렌더링 시(localStorage 확인) → 저장된 토큰 검증 후 자동 로그인 처리 
  - jwt-decode 활용해 토큰에서 사용자 정보(이메일, ID, roles) 추출 

- **로그인**
  - 로그인 시 API 호출 → 토큰 저장 & UserInfo 상태 업데이트

- **로그아웃**
  - 토큰 및 이메일 삭제, 사용자 상태 초기화, 경로에 따라 `/login` 또는 `/admin/login` 리다이렉트

- **권한 관리**
  - hasRole(role: string) → 특정 권한 보유 여부 확인 
  - isAdmin → 관리자 여부 확인 

**3. 관리자 목업 계정 추가**
- `admin@test.com / Admin1234!` 입력 시 API 호출 없이 **mock admin UserInfo** 반환
- 토큰은 mock-token 을 저장하여 API 호출 시에도 인증 헤더를 붙일 수 있도록 처리
- 관리자 페이지 접근 및 대시보드 테스트 가능

**4. 패키지 변경**   
- jwt-decode 추가
  - 토큰 파싱 및 검증을 위해 jwt-decode 라이브러리 설치 
  - package.json, package-lock.json 변경 발생  

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 현재 관리자 계정은 목업 처리 상태 → `/api/admin/signup` 와 같은 API 설계 회의 필요

[에러 해결]
**프론트엔드(api.ts)**
 - 처음에는 `/api/auth/login` 엔드포인트로 요청을 보냈으나 에러 발생 

**백엔드(Spring Security + Controller)**
- 실제 열려 있는 경로는 `/api/user/login`
  - 프론트에서 호출할 때 경로 때문에 계속 404 / Unauthorized 에러가 발생했는데 엔드포인트 수정한 뒤에는 JWT 발급 & 회원가입 연동 확인.

`api.ts` 참고
- 실제 연동된 API와 임시로 만든 API가 존재
