### PR TITLE
[Feature] 관리자 상품 수정 API 추가

### DIFF
--- a/backend/src/main/java/demo/cafemenu/domain/admin/controller/AdminProductController.java
+++ b/backend/src/main/java/demo/cafemenu/domain/admin/controller/AdminProductController.java
@@ -7,7 +7,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -28,4 +30,12 @@ public class AdminProductController {
     return productService.create(req);
   }
 
+  // 제품 수정(admin)
+  @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+  @PutMapping("/{beanId}")
+  @ResponseStatus(HttpStatus.OK)
+  public ProductResponse update(@PathVariable Long beanId,
+      @Valid @RequestBody ProductUpdateRequest req) {
+    return productService.update(beanId, req);
+  }
 }

--- a/backend/src/main/java/demo/cafemenu/domain/admin/controller/AdminProductController.java
+++ b/backend/src/main/java/demo/cafemenu/domain/admin/controller/AdminProductController.java
@@ -1,6 +1,6 @@
 package demo.cafemenu.domain.admin.controller;
 
-import demo.cafemenu.domain.product.dto.ProductCreateRequest;
+import demo.cafemenu.domain.product.dto.ProductRequest;
 import demo.cafemenu.domain.product.dto.ProductResponse;
 import demo.cafemenu.domain.product.service.ProductService;
 import jakarta.validation.Valid;
@@ -26,7 +26,7 @@ public class AdminProductController {
   @PreAuthorize("hasAuthority('ROLE_ADMIN')")
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)
-  public ProductResponse create(@Valid @RequestBody ProductCreateRequest req) {
+  public ProductResponse create(@Valid @RequestBody ProductRequest req) {
     return productService.create(req);
   }
 
@@ -35,7 +35,7 @@ public class AdminProductController {
   @PutMapping("/{beanId}")
   @ResponseStatus(HttpStatus.OK)
   public ProductResponse update(@PathVariable Long beanId,
-      @Valid @RequestBody ProductUpdateRequest req) {
+      @Valid @RequestBody ProductRequest req) {
     return productService.update(beanId, req);
   }
 }

--- a/backend/src/main/java/demo/cafemenu/domain/admin/controller/AdminProductController.java
+++ b/backend/src/main/java/demo/cafemenu/domain/admin/controller/AdminProductController.java
@@ -20,6 +20,7 @@ public class AdminProductController {
 
   private final ProductService productService;
 
+  // 제품 등록(admin)
   @PreAuthorize("hasAuthority('ROLE_ADMIN')")
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)

--- a/backend/src/main/java/demo/cafemenu/domain/product/dto/ProductRequest.java
+++ b/backend/src/main/java/demo/cafemenu/domain/product/dto/ProductRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 
-public record ProductCreateRequest(
+public record ProductRequest(
     @NotBlank(message = "제품명은 필수 입력 항목입니다.")
     @Size(max = 120)
     String name,

--- a/backend/src/main/java/demo/cafemenu/domain/product/entity/Product.java
+++ b/backend/src/main/java/demo/cafemenu/domain/product/entity/Product.java
@@ -34,4 +34,10 @@ public class Product extends BaseTimeEntity {
   @Column(length = 1000)
   private String description;
 
+  public void change(String name, Integer price, String description) {
+    this.name = name;
+    this.price = price;
+    this.description = description;
+  }
+
 }

--- a/backend/src/main/java/demo/cafemenu/domain/product/repository/ProductRepository.java
+++ b/backend/src/main/java/demo/cafemenu/domain/product/repository/ProductRepository.java
@@ -7,4 +7,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
   boolean existsByName(String name);
+
+  boolean existsByNameAndIdNot(String name, Long id);
+
 }

--- a/backend/src/main/java/demo/cafemenu/domain/product/service/ProductService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/product/service/ProductService.java
@@ -40,7 +40,7 @@ public class ProductService {
     // 제품 수정(관리자)
     public ProductResponse update(Long id, ProductRequest req) {
         Product product = productRepository.findById(id)
-            .orElseThrow(new BusinessException(PRODUCT_NOT_FOUND));
+            .orElseThrow(() -> new BusinessException(PRODUCT_NOT_FOUND));
 
         if (productRepository.existsByNameAndIdNot(req.name(), id)) {
             throw new BusinessException(DUPLICATE_PRODUCT_NAME);

--- a/backend/src/main/java/demo/cafemenu/domain/product/service/ProductService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/product/service/ProductService.java
@@ -1,6 +1,7 @@
 package demo.cafemenu.domain.product.service;
 
 import static demo.cafemenu.global.exception.ErrorCode.DUPLICATE_PRODUCT_NAME;
+import static demo.cafemenu.global.exception.ErrorCode.PRODUCT_NOT_FOUND;
 
 import demo.cafemenu.domain.product.dto.ProductRequest;
 import demo.cafemenu.domain.product.dto.ProductResponse;

--- a/backend/src/main/java/demo/cafemenu/domain/product/service/ProductService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/product/service/ProductService.java
@@ -36,6 +36,20 @@ public class ProductService {
           .build()));
     }
 
+    // 제품 수정(관리자)
+    public ProductResponse update(Long id, ProductRequest req) {
+        Product product = productRepository.findById(id)
+            .orElseThrow(new BusinessException(PRODUCT_NOT_FOUND));
+
+        if (productRepository.existsByNameAndIdNot(req.name(), id)) {
+            throw new BusinessException(DUPLICATE_PRODUCT_NAME);
+        }
+
+        product.change(req.name(), req.price(), req.description()); // 영속 엔티티 변경 → dirty checking
+        return toResponse(product);
+
+    }
+
     private ProductResponse toResponse(Product p) {
         return new ProductResponse(p.getId(), p.getName(), p.getPrice(), p.getDescription());
     }

--- a/backend/src/main/java/demo/cafemenu/domain/product/service/ProductService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/product/service/ProductService.java
@@ -46,7 +46,7 @@ public class ProductService {
             throw new BusinessException(DUPLICATE_PRODUCT_NAME);
         }
 
-        product.change(req.name(), req.price(), req.description()); // 영속 엔티티 변경 → dirty checking
+        product.change(req.name(), req.price(), req.description());
         return toResponse(product);
 
     }

--- a/backend/src/main/java/demo/cafemenu/domain/product/service/ProductService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/product/service/ProductService.java
@@ -2,7 +2,7 @@ package demo.cafemenu.domain.product.service;
 
 import static demo.cafemenu.global.exception.ErrorCode.DUPLICATE_PRODUCT_NAME;
 
-import demo.cafemenu.domain.product.dto.ProductCreateRequest;
+import demo.cafemenu.domain.product.dto.ProductRequest;
 import demo.cafemenu.domain.product.dto.ProductResponse;
 import demo.cafemenu.domain.product.entity.Product;
 import demo.cafemenu.domain.product.repository.ProductRepository;
@@ -25,7 +25,7 @@ public class ProductService {
     }
 
     // 제품 등록(관리자)
-    public ProductResponse create(ProductCreateRequest req) {
+    public ProductResponse create(ProductRequest req) {
         if (productRepository.existsByName(req.name())) {
             throw new BusinessException(DUPLICATE_PRODUCT_NAME);
         }

--- a/backend/src/main/java/demo/cafemenu/global/exception/ErrorCode.java
+++ b/backend/src/main/java/demo/cafemenu/global/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
 
   // 404 NOT FOUND
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+  PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
 
   // 409 CONFLICT
   DUPLICATE_PRODUCT_NAME(HttpStatus.CONFLICT, "이미 존재하는 상품명입니다."),


### PR DESCRIPTION
## 📌 과제 설명

관리자(Admin)가 상품 정보를 **수정**할 수 있도록 API를 추가했습니다.
기존 등록 API(POST)에 이어 **수정 API(PUT /api/admin/beans/{beanId})** 를 제공하며, 이름/가격/설명을 변경할 수 있습니다.

---

## 👩‍💻 요구 사항과 구현 내용

* **엔드포인트**

  * `PUT /api/admin/beans/{beanId}` (관리자 전용)
  * 요청 바디: `ProductRequest { name(<=120, not blank), price(>=0, not null), description(<=1000) }`
  * 응답 바디: `ProductResponse { id, name, price, description }`
* **권한**

  * 메서드 단 권한 체크: `@PreAuthorize("hasAuthority('ROLE_ADMIN')")`

* **도메인/서비스**

  * `Product.change(name, price, description)` 추가 
  * `ProductService.update(id, req)` 구현

    * 대상 상품 조회 실패 시 `PRODUCT_NOT_FOUND` 예외
    * **자기 자신 제외 동명 중복 방지**: `existsByNameAndIdNot(req.name(), id)` 사용
    * 수정 후 `ProductResponse`로 변환하여 반환
* **중복 이름 정책**

  * 신규 등록 시: `existsByName(name)`로 중복 방지
  * 수정 시: 동일 상품은 허용, **다른 상품과의 중복만 차단**
* **예외 처리**

  * `PRODUCT_NOT_FOUND`(404), `DUPLICATE_PRODUCT_NAME`(409) 활용

> 관련 변경 요약
>
> * `AdminProductController`: `PUT /api/admin/beans/{beanId}` 추가
> * `ProductService`: `update(...)` 추가, 중복 검사 로직 반영
> * `Product`: `change(...)` 도메인 메서드 추가
> * `ProductRepository`: `existsByNameAndIdNot(String name, Long id)` 필요

---

## ✅ 피드백 반영사항

* (해당 없음)

---

## ✅ PR 포인트 & 궁금한 점

* 응답 규격은 수정 후 리소스 전체를 반환(`200 OK`)합니다.