### PR TITLE
[Feature] 제품 삭제 API 추가 및 전체 조회를 DTO 응답으로 전환

### DIFF
--- a/backend/src/main/java/demo/cafemenu/domain/admin/controller/AdminProductController.java
+++ b/backend/src/main/java/demo/cafemenu/domain/admin/controller/AdminProductController.java
@@ -4,10 +4,12 @@ import demo.cafemenu.domain.product.dto.ProductRequest;
 import demo.cafemenu.domain.product.dto.ProductResponse;
 import demo.cafemenu.domain.product.service.ProductService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -22,6 +24,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminProductController {
 
   private final ProductService productService;
+
+  // 제품 전체 조회(admin)
+  @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+  @GetMapping
+  public List<ProductResponse> list() {
+    return productService.getAll();
+  }
 
   // 제품 등록(admin)
   @PreAuthorize("hasAuthority('ROLE_ADMIN')")

--- a/backend/src/main/java/demo/cafemenu/domain/admin/controller/AdminProductController.java
+++ b/backend/src/main/java/demo/cafemenu/domain/admin/controller/AdminProductController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -37,5 +38,13 @@ public class AdminProductController {
   public ProductResponse update(@PathVariable Long beanId,
       @Valid @RequestBody ProductRequest req) {
     return productService.update(beanId, req);
+  }
+
+  // 제품 삭제(admin)
+  @PreAuthorize("hasAuthority('ROLE_ADMIN')")
+  @DeleteMapping("/{beanId}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void delete(@PathVariable Long beanId) {
+    productService.delete(beanId);
   }
 }

--- a/backend/src/main/java/demo/cafemenu/domain/product/controller/ProductController.java
+++ b/backend/src/main/java/demo/cafemenu/domain/product/controller/ProductController.java
@@ -1,13 +1,12 @@
 package demo.cafemenu.domain.product.controller;
 
-import demo.cafemenu.domain.product.entity.Product;
+import demo.cafemenu.domain.product.dto.ProductResponse;
 import demo.cafemenu.domain.product.service.ProductService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/user")
@@ -17,7 +16,7 @@ public class ProductController {
     private final ProductService productService;
 
     @GetMapping("/beans")
-    public List<Product> getProduct(){
-        return productService.findAll();
+    public List<ProductResponse> getProduct() {
+        return productService.getAll();
     }
 }

--- a/backend/src/main/java/demo/cafemenu/domain/product/service/ProductService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/product/service/ProductService.java
@@ -21,8 +21,12 @@ public class ProductService {
     private final ProductRepository productRepository;
 
     // 전체 상품 목록
-    public List<Product> findAll(){
-        return productRepository.findAll();
+    @Transactional(readOnly = true)
+    public List<ProductResponse> getAll() {
+        return productRepository.findAll()
+            .stream()
+            .map(this::toResponse)
+            .toList();
     }
 
     // 제품 등록(관리자)

--- a/backend/src/main/java/demo/cafemenu/domain/product/service/ProductService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/product/service/ProductService.java
@@ -51,6 +51,13 @@ public class ProductService {
 
     }
 
+    // 제품 삭제(관리자)
+    public void delete(Long id) {
+        Product product = productRepository.findById(id)
+            .orElseThrow(() -> new BusinessException(PRODUCT_NOT_FOUND));
+        productRepository.delete(product);
+    }
+
     private ProductResponse toResponse(Product p) {
         return new ProductResponse(p.getId(), p.getName(), p.getPrice(), p.getDescription());
     }


### PR DESCRIPTION
## 📌 과제 설명

관리자 전용 제품 관리 기능을 확장했습니다.

* 제품 **삭제** API 추가
* 관리자용 **전체 조회** API 추가
* 컨트롤러/서비스에서 **엔티티 직접 노출을 중단**하고 `ProductResponse` DTO로 응답 통일

## 👩‍💻 요구 사항과 구현 내용

* **Controller (`AdminProductController`)**

  * `DELETE /api/admin/beans/{beanId}` : 관리자 권한으로 제품 삭제

    * `@PreAuthorize("hasAuthority('ROLE_ADMIN')")`
    * 성공 시 `204 No Content`
  * `GET /api/admin/beans` : 관리자 권한으로 전체 목록 조회

    * `@PreAuthorize("hasAuthority('ROLE_ADMIN')")`
    * `List<ProductResponse>` 반환
* **Service (`ProductService`)**

  * `public List<ProductResponse> getAll()` 추가

    * `@Transactional(readOnly = true)`
    * `productRepository.findAll()` → `ProductResponse` 매핑
  * `public void delete(Long id)` 구현

    * 미존재 시 `BusinessException(PRODUCT_NOT_FOUND)` 발생
  * 공용 매퍼 `toResponse(Product)` 유지 및 활용
  * 기존 등록/수정 로직은 변동 없음 (중복명 체크 포함)
* **예외 처리**

  * 미존재 제품 삭제 시 `PRODUCT_NOT_FOUND (404)` 반환

## ✅ 피드백 반영사항

* (해당 없음)

## ✅ PR 포인트 & 궁금한 점
