### PR TITLE
feature: 장바구니 내 상품 추가 기능 구현

### DIFF
--- a/backend/src/main/java/demo/cafemenu/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/demo/cafemenu/domain/order/controller/OrderController.java
@@ -23,5 +23,11 @@ public class OrderController {
         List<OrderDto> items = orderService.getPaidOrderByUserId(userId);
         return ResponseEntity.ok(items);
     }
+
+    @PostMapping("/item/{productId}")
+    public ResponseEntity<Void> addItemToCart(@RequestParam Long userId, @PathVariable Long productId) {
+        orderService.addOrderItem(userId, productId);
+        return ResponseEntity.ok().build();
+    }
 }
 

--- a/backend/src/main/java/demo/cafemenu/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/demo/cafemenu/domain/order/controller/OrderController.java
@@ -24,6 +24,7 @@ public class OrderController {
         return ResponseEntity.ok(items);
     }
 
+    // 장바구니에 상품 추가
     @PostMapping("/item/{productId}")
     public ResponseEntity<Void> addItemToCart(@RequestParam Long userId, @PathVariable Long productId) {
         orderService.addOrderItem(userId, productId);

--- a/backend/src/main/java/demo/cafemenu/domain/order/repository/OrderRepository.java
+++ b/backend/src/main/java/demo/cafemenu/domain/order/repository/OrderRepository.java
@@ -5,8 +5,12 @@ import demo.cafemenu.domain.order.entity.OrderStatus;
 import demo.cafemenu.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
     List<Order> findAllByUserAndStatus(User user, OrderStatus status);
+
+    Optional<Order> findByUserAndStatusAndBatchDate(User user, OrderStatus orderStatus, LocalDate today);
 }

--- a/backend/src/main/java/demo/cafemenu/domain/order/service/OrderService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/order/service/OrderService.java
@@ -2,9 +2,11 @@ package demo.cafemenu.domain.order.service;
 
 import demo.cafemenu.domain.order.dto.OrderDto;
 import demo.cafemenu.domain.order.entity.Order;
+import demo.cafemenu.domain.order.entity.OrderItem;
 import demo.cafemenu.domain.order.entity.OrderStatus;
 import demo.cafemenu.domain.order.repository.OrderItemRepository;
 import demo.cafemenu.domain.order.repository.OrderRepository;
+import demo.cafemenu.domain.product.entity.Product;
 import demo.cafemenu.domain.product.repository.ProductRepository;
 import demo.cafemenu.domain.user.entity.User;
 import demo.cafemenu.domain.user.reposiitory.UserRepository;
@@ -14,7 +16,9 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -48,4 +52,59 @@ public class OrderService {
                 ))
                 .toList();
     }
+
+    /* 장바구니 상품 추가
+    - 목록 있으면 수량만 추가, 없으면 생성
+     */
+    public void addOrderItem(Long userId, Long productId) {
+        Order order = getOrder(userRepository.findById(userId).get());
+        Product product = productRepository.findById(productId).get();
+        OrderItem existOrderItem = findOrderItem(order, productId);
+
+        if (existOrderItem != null) {
+            existOrderItem.addQuantity(1);
+        } else {
+            OrderItem newOrderItem = createOrderItem(order, product);
+            order.getItems().add(newOrderItem);
+        }
+        order.recalcTotal();
+        orderRepository.save(order);
+    }
+
+    // PENDING 주문 조회 (없으면 새로 생성)
+    private Order getOrder(User user) {
+        LocalDate today = LocalDate.now();
+
+        Optional<Order> order = orderRepository.findByUserAndStatusAndBatchDate(user, OrderStatus.PENDING, today);
+
+        if (order.isPresent()) {
+            return order.get();
+        } else {
+            Order newOrder = Order.builder()
+                    .user(user)
+                    .batchDate(today)
+                    .status(OrderStatus.PENDING)
+                    .build();
+            return orderRepository.save(newOrder);
+        }
+    }
+
+    // 같은 상품 목록 조회
+    private OrderItem findOrderItem(Order order, Long productId) {
+        return order.getItems().stream()
+                .filter(item -> item.getProductId().equals(productId))
+                .findFirst()
+                .orElse(null);
+    }
+
+    // 장바구니 내 상품 없을 시 상품 생성
+    private OrderItem createOrderItem(Order order, Product product) {
+        return OrderItem.builder()
+                .order(order)
+                .productId(product.getId())
+                .unitPrice(product.getPrice())
+                .quantity(1)
+                .build();
+    }
+
 }


### PR DESCRIPTION
## 📌 과제 설명
- 장바구니에 상품 추가하는 기능을 구현했습니다.

## 👩‍💻 요구 사항과 구현 내용

### 1. `addOrderItem()` 관련 보조 메서드
- `getOrder()` : `PENDING` 주문 조회 후, 없으면 새로 생성합니다.
- `findOrderItem()` : 요청한 상품과 같은 `id`를 조회합니다.
- `createOrderItem()` : 장바구니 내 상품이 없으면 새로 생성합니다.

## ✅ 피드백 반영사항
- @Pathvariable로 변경하였습니다.

## ✅ PR 포인트 & 궁금한 점
- 이전 장바구니 상품추가 브랜치가 부득이하게 충돌을 일으켜 지우게 되었습니다. 참고해주세요.