### PR TITLE
[Feature] 장바구니 일괄 결제(Checkout) API 추가 및 주문 머지 로직 구현

### DIFF
--- a/backend/src/main/java/demo/cafemenu/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/demo/cafemenu/domain/order/controller/OrderController.java
@@ -1,5 +1,6 @@
 package demo.cafemenu.domain.order.controller;
 
+import demo.cafemenu.domain.order.dto.CheckoutRequest;
 import demo.cafemenu.domain.order.dto.OrderDto;
 import demo.cafemenu.domain.order.service.OrderService;
 import demo.cafemenu.global.security.UserDetailsImpl;

--- a/backend/src/main/java/demo/cafemenu/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/demo/cafemenu/domain/order/controller/OrderController.java
@@ -3,12 +3,20 @@ package demo.cafemenu.domain.order.controller;
 import demo.cafemenu.domain.order.dto.OrderDto;
 import demo.cafemenu.domain.order.service.OrderService;
 import demo.cafemenu.global.security.UserDetailsImpl;
+import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,6 +38,14 @@ public class OrderController {
     public ResponseEntity<Void> addItemToCart(@RequestParam Long userId, @PathVariable Long productId) {
         orderService.addOrderItem(userId, productId);
         return ResponseEntity.ok().build();
+    }
+
+    // 사용자의 모든 PENDING 주문을 결제 처리
+    @PostMapping("/orders/checkout")
+    @ResponseStatus(HttpStatus.OK)
+    public void checkoutAll(@AuthenticationPrincipal UserDetailsImpl principal,
+        @Valid @RequestBody CheckoutRequest request) {
+        orderService.checkoutAllPending(principal.getId(), request);
     }
 }
 

--- a/backend/src/main/java/demo/cafemenu/domain/order/dto/CheckoutRequest.java
+++ b/backend/src/main/java/demo/cafemenu/domain/order/dto/CheckoutRequest.java
@@ -1,0 +1,15 @@
+package demo.cafemenu.domain.order.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CheckoutRequest(
+    @NotBlank(message = "배송 주소는 필수입니다.")
+    @Size(max = 200, message = "배송 주소는 200자 이하여야 합니다.")
+    String shippingAddress,
+
+    @NotBlank(message = "우편번호는 필수입니다.")
+    @Pattern(regexp = "\\d{5}", message = "우편번호는 5자리 숫자여야 합니다.")
+    String shippingPostcode
+) {}

--- a/backend/src/main/java/demo/cafemenu/domain/order/entity/Order.java
+++ b/backend/src/main/java/demo/cafemenu/domain/order/entity/Order.java
@@ -86,4 +86,9 @@ public class Order extends BaseTimeEntity {
   public void changeStatus(OrderStatus status) {
     this.status = status;
   }
+
+  public void updateShipping(String address, String postcode) {
+    this.shippingAddress = address;
+    this.shippingPostcode = postcode;
+  }
 }

--- a/backend/src/main/java/demo/cafemenu/domain/order/service/OrderService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/order/service/OrderService.java
@@ -1,9 +1,13 @@
 package demo.cafemenu.domain.order.service;
 
+import static demo.cafemenu.domain.order.entity.OrderStatus.PAID;
+import static demo.cafemenu.domain.order.entity.OrderStatus.PENDING;
+import static demo.cafemenu.global.exception.ErrorCode.USER_NOT_FOUND;
+
+import demo.cafemenu.domain.order.dto.CheckoutRequest;
 import demo.cafemenu.domain.order.dto.OrderDto;
 import demo.cafemenu.domain.order.entity.Order;
 import demo.cafemenu.domain.order.entity.OrderItem;
-import demo.cafemenu.domain.order.entity.OrderStatus;
 import demo.cafemenu.domain.order.repository.OrderItemRepository;
 import demo.cafemenu.domain.order.repository.OrderRepository;
 import demo.cafemenu.domain.product.entity.Product;
@@ -13,12 +17,11 @@ import demo.cafemenu.domain.user.reposiitory.UserRepository;
 import demo.cafemenu.global.exception.BusinessException;
 import demo.cafemenu.global.exception.ErrorCode;
 import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -37,7 +40,7 @@ public class OrderService {
         User user = userRepository.findById(userId).get();
 
         List<Order> paidOrder = orderRepository
-                .findAllByUserAndStatus(user, OrderStatus.PAID);
+                .findAllByUserAndStatus(user, PAID);
         if (paidOrder.isEmpty()) {
             throw new BusinessException(ErrorCode.PAID_ORDERS_NOT_FOUND);
         }
@@ -64,11 +67,55 @@ public class OrderService {
         orderRepository.save(order);
     }
 
+    /**
+     * 사용자의 모든 PENDING 주문을 결제 처리.
+     * - 날짜별로 이미 PAID가 있으면 아이템을 머지하고 PENDING은 삭제(UNIQUE 충돌 방지)
+     * - 없으면 해당 PENDING을 그대로 PAID로 전환
+     * - 배송지/우편번호는 다음 정책으로 반영:
+     *   * PENDING → PAID 전환 시: 요청값으로 설정
+     *   * 기존 PAID로 머지 시: PAID에 배송지가 없으면 설정, 이미 있으면 유지(간단 정책)
+     */
+    public void checkoutAllPending(Long userId, CheckoutRequest req) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+
+        List<Order> pendings = orderRepository.findAllByUserAndStatus(user, PENDING);
+        if (pendings.isEmpty()) {
+            throw new BusinessException(PENDING_ORDERS_NOT_FOUND);
+        }
+
+        for (Order pending : pendings) {
+            Optional<Order> paidOpt = orderRepository.findByUserAndStatusAndBatchDate(
+                user, PAID, pending.getBatchDate());
+
+            if (paidOpt.isPresent()) {
+                Order paid = paidOpt.get();
+
+                // 아이템 머지
+                mergeItems(pending, paid);
+
+                // 배송지: 기존 PAID에 주소가 없으면 이번 요청 값으로 세팅 (있으면 유지)
+                if (paid.getShippingAddress() == null || paid.getShippingAddress().isBlank()) {
+                    paid.updateShipping(req.shippingAddress(), req.shippingPostcode());
+                }
+
+                paid.recalcTotal();
+                orderRepository.delete(pending); // UNIQUE(user,batch_date,status) 충돌 방지
+
+            } else {
+                // PENDING → PAID 전환
+                pending.changeStatus(PAID);
+                pending.updateShipping(req.shippingAddress(), req.shippingPostcode());
+                pending.recalcTotal();
+            }
+        }
+    }
+
     // PENDING 주문 조회 (없으면 새로 생성)
     private Order getOrder(User user) {
         LocalDate today = LocalDate.now();
 
-        Optional<Order> order = orderRepository.findByUserAndStatusAndBatchDate(user, OrderStatus.PENDING, today);
+        Optional<Order> order = orderRepository.findByUserAndStatusAndBatchDate(user, PENDING, today);
 
         if (order.isPresent()) {
             return order.get();
@@ -76,7 +123,7 @@ public class OrderService {
             Order newOrder = Order.builder()
                     .user(user)
                     .batchDate(today)
-                    .status(OrderStatus.PENDING)
+                    .status(PENDING)
                     .build();
             return orderRepository.save(newOrder);
         }

--- a/backend/src/main/java/demo/cafemenu/domain/order/service/OrderService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/order/service/OrderService.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class OrderService {
 
     private final OrderItemRepository orderItemRepository;

--- a/backend/src/main/java/demo/cafemenu/domain/order/service/OrderService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/order/service/OrderService.java
@@ -111,6 +111,27 @@ public class OrderService {
         }
     }
 
+    private void mergeItems(Order fromPending, Order toPaid) {
+        fromPending.getItems().forEach(pi -> {
+            OrderItem exist = toPaid.getItems().stream()
+                .filter(x -> x.getProductId().equals(pi.getProductId()))
+                .findFirst()
+                .orElse(null);
+
+            if (exist != null) {
+                exist.addQuantity(pi.getQuantity());
+            } else {
+                OrderItem added = OrderItem.builder()
+                    .order(toPaid)
+                    .productId(pi.getProductId())
+                    .unitPrice(pi.getUnitPrice())
+                    .quantity(pi.getQuantity())
+                    .build();
+                toPaid.getItems().add(added);
+            }
+        });
+    }
+
     // PENDING 주문 조회 (없으면 새로 생성)
     private Order getOrder(User user) {
         LocalDate today = LocalDate.now();

--- a/backend/src/main/java/demo/cafemenu/domain/order/service/OrderService.java
+++ b/backend/src/main/java/demo/cafemenu/domain/order/service/OrderService.java
@@ -2,6 +2,7 @@ package demo.cafemenu.domain.order.service;
 
 import static demo.cafemenu.domain.order.entity.OrderStatus.PAID;
 import static demo.cafemenu.domain.order.entity.OrderStatus.PENDING;
+import static demo.cafemenu.global.exception.ErrorCode.PENDING_ORDERS_NOT_FOUND;
 import static demo.cafemenu.global.exception.ErrorCode.USER_NOT_FOUND;
 
 import demo.cafemenu.domain.order.dto.CheckoutRequest;

--- a/backend/src/main/java/demo/cafemenu/global/exception/ErrorCode.java
+++ b/backend/src/main/java/demo/cafemenu/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
   PAID_ORDERS_NOT_FOUND(HttpStatus.NOT_FOUND, "결제된 주문 내역이 없습니다."),
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
   PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
+  PENDING_ORDERS_NOT_FOUND(HttpStatus.NOT_FOUND, "결제할 장바구니가 없습니다."),
 
   // 409 CONFLICT
   DUPLICATE_PRODUCT_NAME(HttpStatus.CONFLICT, "이미 존재하는 상품명입니다."),


### PR DESCRIPTION
## 📌 과제 설명

사용자의 장바구니(PENDING 상태 주문)들을 한 번에 **결제 완료(PAID)** 상태로 전환하는 **Checkout API**를 추가했습니다.
결제 시 배송지 정보(주소/우편번호)를 입력받아 주문에 반영하고, 동일 배치일에 이미 존재하는 PAID 주문이 있으면 품목을 **머지**하도록 구현했습니다.

---

## 👩‍💻 요구 사항과 구현 내용

* ### API

  * **POST `/api/user/orders/checkout`**

    * Request Body: `shippingAddress`, `shippingPostcode`
    * 기능: 사용자(PENDING) 주문들을 PAID로 전환. 같은 `batchDate`의 PAID가 있으면 아이템을 합산(머지)하고 PENDING은 삭제해 UNIQUE(user,batch_date,status) 충돌 방지.
    * 검증:

      * `shippingAddress`: `@NotBlank`, `@Size(max=200)`
      * `shippingPostcode`: `@NotBlank`, `@Pattern(\d{5})`

* ### Service 로직

  * `OrderService.checkoutAllPending(userId, request)`

    * 사용자 기준 **모든 PENDING 주문 조회**
    * 각 주문에 대해:

      1. 동일 `batchDate`의 **PAID 주문 존재** → 품목 수량 합산(같은 productId끼리), 기존 PAID의 배송지 없으면 요청값으로 설정 후 **PENDING 삭제**
      2. **PAID 주문 미존재** → 해당 PENDING 주문의 `status = PAID`로 전환하고 배송지/우편번호 설정
    * 각 주문 처리 후 `recalcTotal()` 호출로 총액 갱신
  * `addOrderItem(userId, productId)`

    * 당일자 PENDING 주문을 가져오거나 없으면 생성
    * 동일 상품 존재 시 `quantity +1`, 없으면 신규 라인 추가
    * 총액 재계산

* ### 예외/검증

  * `USER_NOT_FOUND`, `PRODUCT_NOT_FOUND`, `PENDING_ORDERS_NOT_FOUND`, `PAID_ORDERS_NOT_FOUND` 활용

* ### 트랜잭션

  * 클래스 레벨 `@Transactional`

---

## ✅ 피드백 반영사항

* (해당 없음)

---

## ✅ PR 포인트 & 궁금한 점

* **머지 정책**: 기존 PAID에 배송지가 이미 있는 경우 **유지**, 없으면 이번 요청값으로 설정했습니다. 
* **빈 케이스 처리**: 현재 PENDING 주문이 없으면 `PENDING_ORDERS_NOT_FOUND(404)`를 반환합니다.
